### PR TITLE
exec command

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/fromanirh/pack8s/internal/pkg/podman"
+	"github.com/spf13/cobra"
+)
+
+type execOptions struct {
+	commands []string
+}
+
+var execOpt execOptions
+
+// NewExecCommand runs given command inside container
+func NewExecCommand() *cobra.Command {
+	exec := &cobra.Command{
+		Use:   "exec",
+		Short: "exec runs given command in container",
+		RunE:  execCommand,
+		Args:  cobra.MinimumNArgs(2),
+	}
+
+	return exec
+}
+
+func execCommand(cmd *cobra.Command, args []string) error {
+	containerID := args[0]
+	command := args[1:]
+
+	podmanSocket, err := cmd.Flags().GetString("podman-socket")
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	hnd, err := podman.NewHandle(ctx, podmanSocket)
+	if err != nil {
+		return err
+	}
+
+	return hnd.Exec(containerID, command, os.Stdout)
+}

--- a/cmd/okd/run.go
+++ b/cmd/okd/run.go
@@ -35,6 +35,7 @@ type okdRunOptions struct {
 	sshWorkerPort  uint
 	background     bool
 	randomPorts    bool
+	volume         string
 }
 
 var okdRunOpts okdRunOptions
@@ -64,6 +65,7 @@ func NewRunCommand() *cobra.Command {
 	run.Flags().UintVar(&okdRunOpts.sshWorkerPort, "ssh-worker-port", 0, "port on localhost to ssh to worker node")
 	run.Flags().BoolVar(&okdRunOpts.background, "background", false, "go to background after nodes are up")
 	run.Flags().BoolVar(&okdRunOpts.randomPorts, "random-ports", true, "expose all ports on random localhost ports")
+	run.Flags().StringVar(&okdRunOpts.volume, "volume", "", "Bind mount a volume into the container")
 	return run
 }
 
@@ -157,6 +159,7 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		Privileged: &okdRunOpts.privileged,
 		Publish:    &clusterPorts,
 		PublishAll: &okdRunOpts.randomPorts,
+		Volume:     &[]string{okdRunOpts.volume},
 	})
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ func NewRootCommand() *cobra.Command {
 		NewSSHCommand(),
 		NewShowCommand(),
 		NewPruneVolumesCommand(),
+		NewExecCommand(),
 	)
 
 	return root


### PR DESCRIPTION
this command can run user commands inside container.

We need this command, because kubevirtci needs to copy some files from container to host. And with this, we can copy these files to folder which is mounted in host and in container.
/cc @fromanirh 
Signed-off-by: Karel Šimon <ksimon@redhat.com>