### PR TITLE
add new bool flag use-exec to ssh command

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -7,12 +7,12 @@ kubevirtci `56f69bb5867db7517f70a0787b32570a861e124a`
 | Provider          | Run           | Provisioning  | Notes              |
 | ----------------- | ------------- | ------------- | ------------------ |
 | k8s-1.14.6        | Yes           | Planned       |                    |
-| k8s-1.15.1        | In progress   | Planned       |                    |
+| k8s-1.15.1        | Yes           | Planned       |                    |
 | k8s-genie-1.11.1  | Not yet       | N/A           |                    |
 | k8s-multus-1.13.3 | Not yet       | N/A           |                    |
 | okd-4.1           | Yes           | N/A           |                    |
 | okd-4.3           | Yes           | Planned       |                    |
-| os-3.11.0         | Not yet       | N/A           |                    |
+| os-3.11.0         | Yes           | N/A           |                    |
 | os-3.11.0-crio    | Not yet       | N/A           |                    |
 | os-3.11.0-multus  | Not yet       | N/A           |                    |
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -11,6 +11,12 @@ import (
 	"github.com/fromanirh/pack8s/internal/pkg/podman"
 )
 
+type sshOptions struct {
+	useExec bool
+}
+
+var sshOpts sshOptions
+
 // NewSSHCommand returns command to SSH to the cluster node
 func NewSSHCommand() *cobra.Command {
 
@@ -20,6 +26,8 @@ func NewSSHCommand() *cobra.Command {
 		RunE:  ssh,
 		Args:  cobra.MinimumNArgs(1),
 	}
+
+	ssh.Flags().BoolVar(&sshOpts.useExec, "use-exec", false, "use exec connection")
 	return ssh
 }
 
@@ -44,7 +52,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 	container := prefix + "-" + node
 	sshCommand := append([]string{"ssh.sh"}, args[1:]...)
 
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+	if terminal.IsTerminal(int(os.Stdout.Fd())) && !sshOpts.useExec {
 		err = hnd.Terminal(container, sshCommand, os.Stdout)
 	} else {
 		err = hnd.Exec(container, sshCommand, os.Stdout)


### PR DESCRIPTION
This new flag add possibility to choose between exec or terminal during ssh command.
This is needed, because when KUBEVIRT_PROVIDER is set to oc-3.11.0 and terminal is available,
then it requires upgraded connection to attach to container. If call is changed to upgraded, then
ssh gets stuck on iopodman.GetAttachSockets().Call function and will never end.
But if communication is done over exec, then everything works as expected.

//cc @fromanirh I am not sure if this is correct fix. Can you advise me if it is correct place?
Signed-off-by: Karel Šimon <ksimon@redhat.com>