### PR TITLE
Remove terminal connection from ssh command

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -7,15 +7,15 @@ kubevirtci `56f69bb5867db7517f70a0787b32570a861e124a`
 | Provider          | Run           | Provisioning  | Notes              |
 | ----------------- | ------------- | ------------- | ------------------ |
 | k8s-1.14.6        | Yes           | Planned       |                    |
-| k8s-1.15.1        | In progress   | Planned       |                    |
+| k8s-1.15.1        | Yes           | Planned       |                    |
 | k8s-1.16.2        | Yes           | Planned       |                    |
-| k8s-genie-1.11.1  | Not yet       | N/A           |                    |
-| k8s-multus-1.13.3 | Not yet       | N/A           |                    |
+| k8s-genie-1.11.1  | Yes           | N/A           |                    |
+| k8s-multus-1.13.3 | Yes           | N/A           |                    |
 | okd-4.1           | Yes           | N/A           |                    |
 | okd-4.3           | Yes           | Planned       |                    |
-| os-3.11.0         | Not yet       | N/A           |                    |
-| os-3.11.0-crio    | Not yet       | N/A           |                    |
-| os-3.11.0-multus  | Not yet       | N/A           |                    |
+| os-3.11.0         | Yes           | N/A           |                    |
+| os-3.11.0-crio    | Yes           | N/A           |                    |
+| os-3.11.0-multus  | Yes           | N/A           |                    |
 
 Key:
 - Yes: works like gocli, no regression known

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/spf13/cobra"
 
 	"github.com/fromanirh/pack8s/internal/pkg/podman"
@@ -44,10 +42,7 @@ func ssh(cmd *cobra.Command, args []string) error {
 	container := prefix + "-" + node
 	sshCommand := append([]string{"ssh.sh"}, args[1:]...)
 
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
-		err = hnd.Terminal(container, sshCommand, os.Stdout)
-	} else {
-		err = hnd.Exec(container, sshCommand, os.Stdout)
-	}
+	err = hnd.Exec(container, sshCommand, os.Stdout)
+
 	return err
 }


### PR DESCRIPTION
Remove terminal connection from ssh command.
This is needed, because when KUBEVIRT_PROVIDER is set to oc-3.11.0 and terminal is available,
then it requires upgraded connection to attach to container. If call is changed to upgraded, then
ssh gets stuck on iopodman.GetAttachSockets().Call function and will never end.
But if communication is done over exec, then everything works as expected.
Update matrix with supported providers
//cc @fromanirh 