### PR TITLE
cmd: opts to pull all images needed for cluster

### DIFF
--- a/cmd/okd/run.go
+++ b/cmd/okd/run.go
@@ -3,6 +3,7 @@ package okd
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -36,6 +37,19 @@ type okdRunOptions struct {
 	background     bool
 	randomPorts    bool
 	volume         string
+	downloadOnly   bool
+}
+
+func (ro okdRunOptions) WantsNFS() bool {
+	return ro.nfsData != ""
+}
+
+func (ro okdRunOptions) WantsCeph() bool {
+	return false
+}
+
+func (ro okdRunOptions) WantsFluentd() bool {
+	return false
 }
 
 var okdRunOpts okdRunOptions
@@ -124,6 +138,13 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	log.Printf("downloading all the images needed for %s", cluster)
+	err = hnd.PullClusterImages(okdRunOpts, "docker.io/"+cluster)
+	if err != nil || okdRunOpts.downloadOnly {
+		return err
+	}
+	log.Printf("downloaded all the images needed for %s, bringing cluster up", cluster)
+
 	ldgr := ledger.NewLedger(hnd, cmd.OutOrStderr())
 
 	defer func() {
@@ -137,11 +158,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		cancel()
 		ldgr.Done <- fmt.Errorf("Interrupt received, clean up")
 	}()
-	// Pull the cluster image
-	err = hnd.PullImage("docker.io/" + cluster)
-	if err != nil {
-		return err
-	}
 
 	clusterContainerName := prefix + "-cluster"
 	clusterExpose := ports.ToStrings(

--- a/cmd/okd/run.go
+++ b/cmd/okd/run.go
@@ -183,12 +183,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 	clusterNetwork := fmt.Sprintf("container:%s", clusterID)
 
-	// Pull the registry image
-	err = hnd.PullImage(images.DockerRegistryImage)
-	if err != nil {
-		return err
-	}
-
 	// TODO: how to use the user-supplied name?
 	var registryMounts mounts.MountMapping
 	if okdRunOpts.registryVolume != "" {
@@ -221,11 +215,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 	if okdRunOpts.nfsData != "" {
 		nfsData, err := filepath.Abs(okdRunOpts.nfsData)
-		if err != nil {
-			return err
-		}
-
-		err = hnd.PullImage(images.NFSGaneshaImage)
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -231,11 +231,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 
-		err = hnd.PullImage(images.NFSGaneshaImage)
-		if err != nil {
-			return err
-		}
-
 		nfsName := fmt.Sprintf("%s-nfs", prefix)
 		nfsMounts := []string{fmt.Sprintf("type=bind,source=%s,destination=/data/nfs", nfsData)}
 		nfsLabels := []string{fmt.Sprintf("%s=010", podman.LabelGeneration)}
@@ -244,8 +239,8 @@ func run(cmd *cobra.Command, args []string) (err error) {
 			Name:       &nfsName,
 			Label:      &nfsLabels,
 			Mount:      &nfsMounts,
-			Privileged: &runOpts.privileged,
 			Network:    &dnsmasqNetwork,
+			Privileged: &runOpts.privileged,
 		})
 		if err != nil {
 			return err
@@ -253,11 +248,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if runOpts.enableCeph {
-		err = hnd.PullImage(images.CephImage)
-		if err != nil {
-			return err
-		}
-
 		cephName := fmt.Sprintf("%s-ceph", prefix)
 		cephLabels := []string{fmt.Sprintf("%s=011", podman.LabelGeneration)}
 		_, err = ldgr.RunContainer(iopodman.Create{
@@ -286,11 +276,6 @@ func run(cmd *cobra.Command, args []string) (err error) {
 
 		if _, err = os.Stat(logDir); os.IsNotExist(err) {
 			os.Mkdir(logDir, 0755)
-		}
-
-		err = hnd.PullImage(images.FluentdImage)
-		if err != nil {
-			return err
 		}
 
 		fluentdMounts := []string{fmt.Sprintf("type=bind,source=%s,destination=/fluentd/log/collected", logDir)}

--- a/internal/pkg/images/images.go
+++ b/internal/pkg/images/images.go
@@ -10,3 +10,9 @@ const (
 	// FluentdImage contains the reference to fluentd docker image
 	FluentdImage = "docker.io/fluent/fluentd:v1.2-debian"
 )
+
+type Requests interface {
+	WantsNFS() bool
+	WantsCeph() bool
+	WantsFluentd() bool
+}


### PR DESCRIPTION
In this change we reorganize the way we pull the images needed
for a cluster to run.
Previously, we incrementally downloaded images as we go, alternating
download and setup. While images are cached on the host, this made
the first run less predictable, because download time (and timouts)
were intermixed with setup time (and timeouts!)
This is especially important for CI/functests, where hosts are ephemeral
VMs, so caching benefits are reduced greatly, or inexistent.

With this patch, we can move all the downloads at the beginning of
the run flow. This way, when the phase is done, we know that every
delay or timeout is caused by setup only, and not by, say, slow network.

The `run` and `pull` subcommand gained options to download all the
images needed by cluster and, in case of `run`, just exit after
the download is done. This helps warming up the image cache on the host,
so every run, including the first one, wastes no time in download.

Again, this is expected to be used and useful on CI and functests.

Being a reshuffle of steps we need anyway, we expect no real change
in behaviour for the `run` command.

Fixes: https://github.com/fromanirh/pack8s/issues/32
Signed-off-by: Francesco Romani <fromani@redhat.com>