### PR TITLE
Add registry opt

### DIFF
--- a/cmd/cmdutil/util.go
+++ b/cmd/cmdutil/util.go
@@ -17,8 +17,16 @@ type CommonOpts struct {
 	Prefix       string
 	PodmanSocket string
 	Verbose      int
+	Registry     string
 	IsTTY        bool
 	Color        bool
+}
+
+func AddCommonOpts(rootCmd *cobra.Command) {
+	rootCmd.PersistentFlags().StringP("prefix", "p", "kubevirt", "Prefix to identify containers")
+	rootCmd.PersistentFlags().StringP("podman-socket", "s", podman.DefaultSocket, "Path to podman-socket")
+	rootCmd.PersistentFlags().IntP("verbose", "v", 3, "verbosiness level [1,5)")
+	rootCmd.PersistentFlags().StringP("container-registry", "R", "docker.io", "Registry to pull cluster images from")
 }
 
 func GetCommonOpts(cmd *cobra.Command) (CommonOpts, error) {
@@ -31,6 +39,10 @@ func GetCommonOpts(cmd *cobra.Command) (CommonOpts, error) {
 		return CommonOpts{}, err
 	}
 	verbose, err := cmd.Flags().GetInt("verbose")
+	if err != nil {
+		return CommonOpts{}, err
+	}
+	registry, err := cmd.Flags().GetString("container-registry")
 	if err != nil {
 		return CommonOpts{}, err
 	}
@@ -52,6 +64,7 @@ func GetCommonOpts(cmd *cobra.Command) (CommonOpts, error) {
 		Verbose:      verbose,
 		IsTTY:        isatty.IsTerminal(os.Stderr.Fd()),
 		Color:        color,
+		Registry:     registry,
 	}, nil
 }
 

--- a/cmd/okd/run.go
+++ b/cmd/okd/run.go
@@ -131,8 +131,8 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	log.Infof("downloading all the images needed for %s", cluster)
-	err = hnd.PullClusterImages(okdRunOpts, "docker.io/"+cluster)
+	log.Noticef("downloading all the images needed for %s (from %s)", cluster, cOpts.Registry)
+	err = hnd.PullClusterImages(okdRunOpts, cOpts.Registry, cluster)
 	if err != nil || okdRunOpts.downloadOnly {
 		return err
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -87,11 +87,11 @@ func pullImage(cmd *cobra.Command, args []string) error {
 		hnd.PullReporter = tpp
 	}
 
-	ref := args[0]
+	cluster := args[0]
 	if pullOpts.auxImages {
 		// if we always do PullClusterImages, we bring the docker registry, which is something
 		// we may actually don't want to do here (wasted work)
-		return hnd.PullClusterImages(pullOpts, ref)
+		return hnd.PullClusterImages(pullOpts, cOpts.Registry, cluster)
 	}
-	return hnd.PullImage(ref)
+	return hnd.PullImageFromRegistry(cOpts.Registry, cluster)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/fromanirh/pack8s/internal/pkg/podman"
+
+	"github.com/fromanirh/pack8s/cmd/cmdutil"
 )
 
 // NewRootCommand returns entrypoint command to interact with all other commands
@@ -22,9 +24,7 @@ func NewRootCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	root.PersistentFlags().StringP("prefix", "p", "kubevirt", "Prefix to identify containers")
-	root.PersistentFlags().StringP("podman-socket", "s", podman.DefaultSocket, "Path to podman-socket")
-	root.PersistentFlags().IntP("verbose", "v", 3, "verbosiness level [1,5)")
+	cmdutil.AddCommonOpts(root)
 
 	root.AddCommand(
 		NewPortCommand(),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -140,8 +140,8 @@ func run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	log.Noticef("downloading all the images needed for %s", cluster)
-	err = hnd.PullClusterImages(runOpts, "docker.io/"+cluster)
+	log.Noticef("downloading all the images needed for %s (from %s)", cluster, cOpts.Registry)
+	err = hnd.PullClusterImages(runOpts, cOpts.Registry, cluster)
 	if err != nil || runOpts.downloadOnly {
 		return err
 	}

--- a/internal/pkg/podman/podman.go
+++ b/internal/pkg/podman/podman.go
@@ -363,6 +363,11 @@ func (hnd *Handle) ListImages() ([]iopodman.Image, error) {
 	return iopodman.ListImages().Call(hnd.ctx, hnd.conn)
 }
 
+func (hnd *Handle) PullImageFromRegistry(registry, image string) error {
+	imageRef := registry + "/" + image // TODO: is that a path? an URL? something else?
+	return hnd.PullImage(imageRef)
+}
+
 func (hnd *Handle) PullImage(ref string) error {
 	_, err := hnd.reconnect()
 	if err != nil {
@@ -389,9 +394,9 @@ func (hnd *Handle) PullImage(ref string) error {
 	return fmt.Errorf("failed to download %s %d times, giving up.", ref, len(tries))
 }
 
-func (hnd *Handle) PullClusterImages(reqs images.Requests, clusterImage string) error {
+func (hnd *Handle) PullClusterImages(reqs images.Requests, clusterRegistry, clusterImage string) error {
 	var err error
-	err = hnd.PullImage(clusterImage)
+	err = hnd.PullImageFromRegistry(clusterRegistry, clusterImage)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add option to specify the registry from which `pack8s` should pull the images.
Needed to support kubevirt providers >= 1.17 on kubevirtci